### PR TITLE
changed size of column user_picture in table users from 300 to 305

### DIFF
--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -176,5 +176,6 @@
     <include file="db/changelog/logs/ch-drop-places-table-Bokalo.xml"/>
     <include file="db/changelog/logs/ch-drop-news-subscribers-table-Bokalo.xml"/>
     <include file="db/changelog/logs/ch-drop-user-friends-table-Bokalo.xml"/>
+    <include file="db/changelog/logs/ch-change-users-addColumn-Klopov.xml"/>
 </databaseChangeLog>
 

--- a/dao/src/main/resources/db/changelog/logs/ch-change-users-addColumn-Klopov.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-change-users-addColumn-Klopov.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet author="Dmytro Klopov" id="klopov-1" >
+        <modifyDataType
+                columnName="profile_picture"
+                newDataType="varchar(305)"
+                tableName="users"/>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
For saving Facebook picture_url we need to have a size of column at least 305 characters. So because of it I wanted to change to size to 305.